### PR TITLE
Where parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Furthermore, Node-DBI provides a DBSelect class which allows easy and readable S
  * __where( whereStr, value )__:  
      * adds a WHERE clause using AND 
      * if __value__ is not null, all the "?" occurences in __whereStr__ will be replaced with the safely escaped value
+     * __value__ may be an array, it will be mapped to a parenthesized SQL list
      * the clause will be surrounded with parenthesis in the generated SQL, this way ```.where('id=? OR name=?')``` will work like it does in ZendDb.
  * __orWhere( whereStr, value )__ : just like __where__ but adds a WHERE clause using OR
  * __whereGroup( num )__ : 

--- a/lib/dbSelect.js
+++ b/lib/dbSelect.js
@@ -102,7 +102,7 @@ DBSelect.prototype.where = function( whereStr, value, clauseType )
   
   if( (clauseType == 'OR' || clauseType == 'AND') && whereStr && value ) {
 	if(_.isArray(value))
-		value = value.map((function (v) { return this._adapter.escape(v); }).bind(this)).join(', ');
+		value = '(' + value.map((function (v) { return this._adapter.escape(v); }).bind(this)).join(', ') + ')';
 	else
 		value = this._adapter.escape(value);
 

--- a/test/db-select.js
+++ b/test/db-select.js
@@ -258,6 +258,32 @@ var adapterTestSuite = function( adapterName, callback )
       }
       
     },
+
+    'an advanced WHERE clause, with more parenthetical grouping, compound statements and an array value': {
+      topic: function()
+      {
+        return dbWrapper.getSelect()
+          .from('user')
+          .whereGroupClose()      // Erroneous whereGroupClose to be handled
+          .whereGroup(3)   // Multiple group start
+          .where('enabled=1')
+          .where( 'id=?', 10 )
+          .whereGroupClose()
+          .where( 'first_name=\'Dr.\' OR first_name IN ?', ['Bob', 'Mike'])
+          .whereGroup()
+          .where( 'last_name LIKE ?', '%Benton%' )
+          .orWhere( 'nickname=?', '"`\'éàèç' )
+          .whereGroupClose(2);
+          // Automatic closing of leftover groups
+      },
+      
+      'assembled Select is OK': function( select )
+      {
+        var user = dbWrapper._adapter.escapeTable('user');
+        assert.equal( select.assemble(), 'SELECT '+user+'.* FROM '+user+' WHERE ((((enabled=1) AND (id=10)) AND (first_name=\'Dr.\' OR first_name IN (\'Bob\', \'Mike\')) AND ((last_name LIKE \'%Benton%\') OR (nickname='+dbWrapper.escape('"`\'éàèç')+'))))' );
+      }
+      
+    },
     
     'a "WHERE clause" only SELECT ': {
       topic: function()


### PR DESCRIPTION
I added parenthesis to the where clauses like we discussed.  I also updated the unit tests and the README.

There was a bug in `.where()` involving passing it an array for **value**.  It just needed some added parenthesis.
