### PR TITLE
exception for "terminating connection due to administrator command"

### DIFF
--- a/lib/adapters/adapter--pg.js
+++ b/lib/adapters/adapter--pg.js
@@ -93,6 +93,9 @@ Adapter.prototype.connect = function()
     //that._dbClient = client;
     (_.bind(that._onConnectionInitialization, that))(err);
   });
+    this._dbClient.on('error', function(err, client) {
+      console.log('ERROR: postgres connect exception: ' + err.message);
+    });
 };
 
 


### PR DESCRIPTION
this would bix a bug - when app hits max connections limit in pg db the whole app crashes with:

events.js:72
        throw er; // Unhandled 'error' event
              ^
error: terminating connection due to administrator command

code is borrowed from https://github.com/sequelize/sequelize/issues/1854