### PR TITLE
Add support for Postgres DSN, i.e. DATABASE_URL

### DIFF
--- a/lib/adapters/adapter--pg.js
+++ b/lib/adapters/adapter--pg.js
@@ -45,7 +45,11 @@ function Adapter( dbWrapper, connectionParams )
   // "Super" constructor is called
   DBAdapterAbstract.call( this, dbWrapper, connectionParams );
   var cfg = this._connectionParams;
-  this._pgUrl = 'pg://' + cfg.user + ':' + cfg.password + '@' + cfg.host + '/' + cfg.database;
+  if (connectionParams["dsn"]) {
+    this._pgUrl = connectionParams["dsn"];
+  } else {
+    this._pgUrl = 'pg://' + cfg.user + ':' + cfg.password + '@' + cfg.host + '/' + cfg.database;
+  }
   this._dbClient = new pg.Client(this._pgUrl);
   
 }

--- a/test/config.js.dist
+++ b/test/config.js.dist
@@ -16,6 +16,10 @@ var connectionParams = {
         database: 'node_dbi_test'
     },
 
+    pg_dsn: {
+        dsn: 'postgres://localhost:5432/node_dbi_test'
+    },
+
     sqlite: {
         database: ':memory:'
     }
@@ -37,6 +41,9 @@ module.exports.getDbConfig = function( adapterName )
         case 'pg':
             return connectionParams.pgsql;
 
+        case 'pg_dsn':
+            return connectionParams.pgsql_dsn;
+
         default:
             throw new Error('Unknown Adapter "'+adapterName+'" !');
 
@@ -48,5 +55,6 @@ module.exports.testedAdapterNames = [
     'sqlite3',
     'mysql',
     'mysql-libmysqlclient',
-    'pg'
+    'pg',
+    'pg_dsn'
 ];


### PR DESCRIPTION
 * Fixes #32 

Adds support for passing a DSN string instead of user/pass/database, etc. with the "dsn" key. The config is still kept in JSON in order to keep other uses of the JSON config like `JSON.Stringify` on debug, etc. and for maximum compatibility.